### PR TITLE
Fix loss computation, fix flops for ResNet model, fix multi-gpu eval bug, upgrade to PyTorch 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Your prompt should now be prefaced with `(shift)`, as in
 2. Install `pytorch` and `torchvision`. Access [pytorch.org](http://pytorch.org), scroll down to the "Getting Started" section, and select the appropriate OS, package manager, Python, and CUDA build. For example, selecting Linux, pip, Python2.7, and CUDA 8 gives the following, as of the time of this writing
 
 ```
-pip install http://download.pytorch.org/whl/cu80/torch-0.3.0.post4-cp27-cp27mu-linux_x86_64.whl 
-pip install torchvision 
+pip install pytorch torchvision # upgrade to latest PyTorch 0.4.1 official stable version
 ```
 
 3. Clone the repository

--- a/count.py
+++ b/count.py
@@ -1,7 +1,5 @@
 from models import ResNet20
 from models import ShiftResNet20
-from models import ResNet44
-from models import ShiftResNet44
 from models import ResNet56
 from models import ShiftResNet56
 from models import ResNet110
@@ -14,8 +12,6 @@ import argparse
 all_models = {
     'resnet20': ResNet20,
     'shiftresnet20': ShiftResNet20,
-    'resnet44': ResNet44,
-    'shiftresnet44': ShiftResNet44,
     'resnet56': ResNet56,
     'shiftresnet56': ShiftResNet56,
     'resnet110': ResNet110,

--- a/eval.py
+++ b/eval.py
@@ -55,19 +55,20 @@ def test(epoch):
     correct = 0
     total = 0
     for batch_idx, (inputs, targets) in enumerate(testloader):
-        if use_cuda:
-            inputs, targets = inputs.cuda(), targets.cuda()
-        inputs, targets = Variable(inputs, volatile=True), Variable(targets)
-        outputs = net(inputs)
-        loss = criterion(outputs, targets)
+        with torch.no_grad():
+            if use_cuda:
+                inputs, targets = inputs.cuda(), targets.cuda()
+            inputs, targets = Variable(inputs), Variable(targets)
+            outputs = net(inputs)
+            loss = criterion(outputs, targets)
 
-        test_loss += loss.data[0]
-        _, predicted = torch.max(outputs.data, 1)
-        total += targets.size(0)
-        correct += predicted.eq(targets.data).cpu().sum()
+            test_loss += loss.item() * targets.size(0)
+            _, predicted = torch.max(outputs.data, 1)
+            total += targets.size(0)
+            correct += predicted.eq(targets.data).cpu().sum()
 
         progress_bar(batch_idx, len(testloader), 'Loss: %.3f | Acc: %.3f%% (%d/%d)'
-            % (test_loss/(batch_idx+1), 100.*correct/total, correct, total))
+            % (test_loss/total, 100.*correct/total, correct, total))
     return ' '
 
 for pattern in args.model:

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -82,7 +82,7 @@ class ResNet(nn.Module):
         for mod in (self.layer1, self.layer2, self.layer3):
             for layer in mod:
                 flops += layer.flops()
-        return int_h*int_w*9*self.in_planes + out_w*self.num_classes + flops
+        return int_h*int_w*9*self.in_planes*3 + out_w*self.num_classes + flops
 
     def forward(self, x):
         out = F.relu(self.bn1(self.conv1(x)))


### PR DESCRIPTION
* Usually the last batch size is smaller than before when number of epochs is not divided by the number of samples in the whole dataset, thus set overall loss to `test_loss/(batch_idx+1)` is unfair for the last batch.
* Flops of the first convolution in ResNet is supposed to be multiplied by the input channel of image, namely 3, in my opinion.
* revert to original version of [line 209 in main.py](https://github.com/alvinwan/shiftresnet-cifar/blob/master/main.py#L209) against this [latest pull](https://github.com/alvinwan/shiftresnet-cifar/pull/4) ```'net': net.module if use_cuda and torch.cuda.device_count()>1 else net
```means if net is trained with one GPU, `net` instead of `net.module` will be saved as checkpoint, but the behaviour will cause confilct with `eval.py` if evaluated with more than one GPU (eval still with one GPU is safe) for `DataParallel` class is directly loaded.
* Upgrade to latest PyTorch 0.4.1 version code, previously recommended 0.3.0.post4 is suffered from a known PyTorch inside bug with messages like ```RuntimeError: Assertion `pos >= 0 && pos < buffer.size()` failed.``` during my test process.